### PR TITLE
Add Panorama Captions interface

### DIFF
--- a/p2ce/caption.d.ts
+++ b/p2ce/caption.d.ts
@@ -1,0 +1,31 @@
+/**
+ * @packageDocumentation
+ * Captioning Interface
+ */
+
+interface Caption {
+	bLowPriority: boolean;
+	bSFX: boolean;
+	flNoRepeat: number;
+	flDelay: number;
+	flLifetimeOverride: number;
+	text: string;
+	options: Map<string, string>;
+}
+
+declare enum CloseCaptioningExpiryMethod {
+	STACK = 0,
+	INDIVIDUAL = 1
+}
+
+interface GlobalEventNameMap {
+	DisplayCaption: (token: string, caption: Caption, lifetime: number, emitTime: number) => void;
+	BadCaption: (token: string, lifetime: number, emitTime: number) => void;
+	EndCaption: (token: string) => void;
+}
+
+declare namespace ClosedCaptionsAPI {
+	function SetMaxCaptionEntries(num: number): void;
+	function GetAvailableLanguages(): Array<string>;
+	function SetCaptioningExpiryMethod(method: CloseCaptioningExpiryMethod): void;
+}

--- a/shared/panels.d.ts
+++ b/shared/panels.d.ts
@@ -454,6 +454,12 @@ declare interface Label extends AbstractPanel<'Label'> {
 	SetLocalizationString(text: string): void;
 
 	SetProceduralTextThatIPromiseIsLocalizedAndEscaped(text: string, allowDialogVariables: boolean): void;
+
+	/**
+	 * Approximates the height this label would have
+	 * if the passed in text was set, given a pre-determined width.
+	 */ 
+	GetHeightForText(width: number, text: string): number;
 }
 
 declare interface Movie extends AbstractPanel<'Movie'> {


### PR DESCRIPTION
Internal MR must pass before merging this.

Adds the interfaces & events for Panorama Closed Captions. Also adds two new Label methods for visual parity against VGUI captions.