### PR TITLE
fix: LoadingScreen mapping, add TooltipPanel & SteamInputAction panels

### DIFF
--- a/shared/panels.d.ts
+++ b/shared/panels.d.ts
@@ -48,6 +48,10 @@ declare interface PanelTagNameMap {
 	ColorPicker: ColorPicker;
 	Tooltip: Tooltip;
 	TextTooltip: TextTooltip;
+	TooltipPanel: TooltipPanel;
+	SteamInputAction: SteamInputAction;
+	SteamInputActionLabel: SteamInputActionLabel;
+	SteamInputActionGlyph: SteamInputActionGlyph;
 }
 
 /**
@@ -1045,4 +1049,20 @@ declare interface Tooltip extends AbstractPanel<'Tooltip'> {
 
 declare interface TextTooltip extends AbstractPanel<'TextTooltip'> {
 	GetTooltipTarget(): GenericPanel;
+}
+
+declare interface TooltipPanel extends AbstractPanel<'TooltipPanel'> {
+	
+}
+
+declare interface SteamInputAction extends AbstractPanel<'SteamInputAction'> {
+
+}
+
+declare interface SteamInputActionLabel extends AbstractPanel<'SteamInputActionLabel'> {
+
+}
+
+declare interface SteamInputActionGlyph extends AbstractPanel<'SteamInputActionGlyph'> {
+
 }

--- a/shared/panels.d.ts
+++ b/shared/panels.d.ts
@@ -24,7 +24,7 @@ declare interface PanelTagNameMap {
 	ModelPanel: ModelPanel;
 	UICanvas: UICanvas;
 	BackbufferImagePanel: BackbufferImagePanel;
-	LoadingScreen: BackbufferImagePanel;
+	LoadingScreen: LoadingScreen;
 	MainMenu: MainMenu;
 	SettingsSlider: SettingsSlider;
 	SettingsKeyBinder: SettingsKeyBinder;


### PR DESCRIPTION
Fixes:
- `LoadingScreen` being mapped to type `BackbufferImagePanel`

Adds:
- `TooltipPanel`
- `SteamInputAction`
- `SteamInputActionLabel`
- `SteamInputActionGlyph`

These don't appear to have any accessors/setters, nor any callable functions from JS. So these are empty.