### PR TITLE
feat: GameInterfaceAPI.GetWindowDimensions(), ConVarColorDisplays.RestoreCVarDefault()

### DIFF
--- a/shared/apis.d.ts
+++ b/shared/apis.d.ts
@@ -461,6 +461,9 @@ declare namespace GameInterfaceAPI {
 
 	/** Get the AppIDs of all currently mounted Steam apps. */
 	function GetMountedSteamApps(): number[];
+
+	/** Gets the dimensions (width & height) and calculated aspect ratio of the game window. */
+	function GetWindowDimensions(): { width: number, height: number, aspectRatio: number };
 }
 
 /** @group api */

--- a/shared/panels.d.ts
+++ b/shared/panels.d.ts
@@ -967,6 +967,9 @@ declare interface SettingsEnumDropDown extends AbstractPanel<'SettingsEnumDropDo
 
 declare interface ConVarColorDisplay extends AbstractPanel<'ConVarColorDisplay'> {
 	convar: string;
+
+	/** Set the cvar back to default */
+	RestoreCVarDefault(): void;
 }
 
 declare type SettingsPanel =


### PR DESCRIPTION
~~Requires internal MR to pass first.~~

Adds `GameInterfaceAPI.GetWindowDimensions()` for scripts, returning an object containing the window width, height, and calculated aspect ratio. Also adds `RestoreCVarDefault` to `ConVarColorDisplays`.